### PR TITLE
build: limit mac target to Apple Silicon dmg

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,14 @@
     "mac": {
       "icon": "./icon/icon.icns",
       "category": "public.app-category.productivity",
+      "target": [
+        {
+          "target": "dmg",
+          "arch": [
+            "arm64"
+          ]
+        }
+      ],
       "identity": null
     },
     "dmg": {


### PR DESCRIPTION
## Summary\n- limit the mac build target to Apple Silicon dmg packages\n- make the packaging target explicit for the currently supported mac build\n- keep other platform targets unchanged\n\n## Testing\n- not run (packaging config change only)